### PR TITLE
Configure Playwright auth setup

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,21 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+const baseURL = process.env.BASE_URL ?? 'https://demo.playwright.dev/todomvc';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './e2e',
+  testDir: './tests',
+  globalSetup: require.resolve('./tests/setup/global.setup'),
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -26,7 +29,9 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL,
+
+    storageState: path.resolve(__dirname, 'storageState.json'),
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- load environment variables in the Playwright config so the base URL can be provided for login/logout flows
- run the test suite from the `tests` directory with an auth storage state produced by the global setup
- share the generated storage state with each project via the `use` options to keep login-dependent specs stable

## Testing
- npx playwright test *(fails: required browsers cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e667baafac83219a6fd94af1b240b4